### PR TITLE
fix(docs): invalid link

### DIFF
--- a/process/engineering/README.md
+++ b/process/engineering/README.md
@@ -10,7 +10,3 @@ description: >-
 
 These guides are designed to be best used with a mentor. The pages you are about to read in this section are references to help you know what we think you'd need to know in the context of writing software at nilenso.
 
-{% content-ref url="reading-material.md" %}
-[reading-material.md](reading-material.md)
-{% endcontent-ref %}
-


### PR DESCRIPTION
leads to `https://reading-material.md` 

the actual markdown is included in the enlisting that follows in the render